### PR TITLE
More liberal python version, ~3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A cookie cutter repo template to base other repos on"
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = "3.11.6"
+python = "~3.11"
 pandas = "^2.1.1"
 numpy = "^1.26.0"
 jupyter = "^1.0.0"


### PR DESCRIPTION

Changed python version in pyproject.toml to ~3.11, meaning any version >=3.11.0,<3.12 is allowed. This means we don't all have to have the exact same patch version installed